### PR TITLE
feat: Export typings to separate files

### DIFF
--- a/lib/src/components/AddressWithActions.d.tsx
+++ b/lib/src/components/AddressWithActions.d.tsx
@@ -1,0 +1,9 @@
+import {TAddress} from '../utils/utils';
+
+export type TAddressWithActions = {
+	address: TAddress;
+	explorer: string;
+	truncate?: number;
+	wrapperClassName?: string;
+	className?: string;
+};

--- a/lib/src/components/AddressWithActions.tsx
+++ b/lib/src/components/AddressWithActions.tsx
@@ -1,22 +1,16 @@
 import	React, {ReactElement}				from	'react';
-import	{toENS, copyToClipboard, TAddress}	from	'../utils/utils';
+import	{toENS, copyToClipboard}			from	'../utils/utils';
 import	IconLinkOut							from	'../icons/IconLinkOut';
 import	IconCopy							from	'../icons/IconCopy';
+import type * as AddressWithActionsTypes	from	'./AddressWithActions.d';
 
-export type	TAddressWithActions = {
-	address: TAddress,
-	explorer: string,
-	truncate?: number,
-	wrapperClassName?: string
-	className?: string
-};
 function	AddressWithActions({
 	address,
 	explorer = 'https://etherscan.io',
 	truncate = 5,
 	wrapperClassName,
 	className = 'font-mono font-bold text-left text-typo-primary'
-}: TAddressWithActions): ReactElement {
+}: AddressWithActionsTypes.TAddressWithActions): ReactElement {
 	return (
 		<span className={`flex flex-row items-center ${wrapperClassName}`}>
 			<p className={className}>{toENS(address, truncate > 0, truncate)}</p>

--- a/lib/src/components/DescriptionList.d.tsx
+++ b/lib/src/components/DescriptionList.d.tsx
@@ -1,0 +1,11 @@
+import {ReactElement} from 'react';
+
+export type TDescriptionListOption = {
+	title: string;
+	details: string | ReactElement;
+};
+  
+export type TDescriptionList = {
+	options: TDescriptionListOption[];
+	className?: string;
+};

--- a/lib/src/components/DescriptionList.tsx
+++ b/lib/src/components/DescriptionList.tsx
@@ -1,16 +1,7 @@
-import React, {ReactElement} from 'react';
+import React, {ReactElement} 			from 	'react';
+import type * as DescriptionListTypes	from	'./DescriptionList.d';
 
-export type TDescriptionListOption = {
-	title: string;
-	details: string | ReactElement;
-}
-  
-export type TDescriptionList = {
-	options: TDescriptionListOption[];
-	className?: string;
-}
-
-function DescriptionList({options, className, ...props}: TDescriptionList): ReactElement {
+function DescriptionList({options, className, ...props}: DescriptionListTypes.TDescriptionList): ReactElement {
 	return (
 		<dl className={`flex flex-col space-y-4 ${className}`} {...props}>
 			{options.map((option): ReactElement => (

--- a/lib/src/components/Dropdown.d.tsx
+++ b/lib/src/components/Dropdown.d.tsx
@@ -1,0 +1,16 @@
+import {ReactElement} from 'react';
+
+export type TDropdownOption = {
+	icon?: ReactElement;
+	value: string | number;
+	label: string;
+};
+
+export type TDropdownProps = {
+	options: TDropdownOption[];
+	defaultOption: TDropdownOption;
+	selected: TDropdownOption;
+	onSelect:
+		| React.Dispatch<React.SetStateAction<TDropdownOption>>
+		| ((option: TDropdownOption) => void);
+};

--- a/lib/src/components/Dropdown.tsx
+++ b/lib/src/components/Dropdown.tsx
@@ -2,21 +2,9 @@
 import	React, {ReactElement}	from	'react';
 import	{Menu, Transition}		from	'@headlessui/react';
 import	IconChevron				from	'../icons/IconChevron';
+import type * as DropdownTypes	from	'./Dropdown.d';
 
-export type TDropdownOption = {
-	icon?: ReactElement;
-	value: string | number;
-	label: string;
-}
-  
-export type TDropdownProps = {
-	options: TDropdownOption[];
-	defaultOption: TDropdownOption;
-	selected: TDropdownOption;
-	onSelect: React.Dispatch<React.SetStateAction<TDropdownOption>> | ((option: TDropdownOption) => void);
-}
-
-function Dropdown({options, defaultOption, selected, onSelect}: TDropdownProps): ReactElement {
+function Dropdown({options, defaultOption, selected, onSelect}: DropdownTypes.TDropdownProps): ReactElement {
 	return (
 		<div>
 			<Menu as={'menu'} className={'inline-block relative text-left'}>

--- a/lib/src/components/Modal.d.tsx
+++ b/lib/src/components/Modal.d.tsx
@@ -1,0 +1,7 @@
+import {ReactElement} from 'react';
+
+export type TModal = {
+	isOpen: boolean;
+	onClose: () => void;
+	children: ReactElement;
+};

--- a/lib/src/components/Modal.tsx
+++ b/lib/src/components/Modal.tsx
@@ -1,12 +1,8 @@
 import	React, {ReactElement, useRef}	from	'react';
 import	{Dialog, Transition}			from	'@headlessui/react';
+import * as ModalTypes					from 	'./Modal.d';
 
-type		TModal = {
-	isOpen: boolean,
-	onClose: () => void
-	children: ReactElement,
-}
-function	Modal({isOpen, onClose, children}: TModal): ReactElement {
+function	Modal({isOpen, onClose, children}: ModalTypes.TModal): ReactElement {
 	const	ref = useRef() as React.MutableRefObject<HTMLDivElement>;
 
 	return (

--- a/lib/src/components/ModalLogin.d.tsx
+++ b/lib/src/components/ModalLogin.d.tsx
@@ -1,0 +1,6 @@
+export type	TModalLogin = {
+	isOpen: boolean;
+	set_isOpen: React.Dispatch<React.SetStateAction<boolean>>;
+	connect: (_providerType: number) => Promise<void>;
+	walletType: {[key: string]: number};
+};

--- a/lib/src/components/ModalLogin.tsx
+++ b/lib/src/components/ModalLogin.tsx
@@ -2,14 +2,9 @@ import	React, {ReactElement}		from	'react';
 import	{Modal}						from	'./Modal';
 import	IconWalletMetamask			from	'../icons/IconWalletMetamask';
 import	IconWalletWalletConnect		from	'../icons/IconWalletWalletConnect';
+import * as ModalLoginTypes			from 	'./ModalLogin.d';
 
-type		TModalLogin = {
-	isOpen: boolean,
-	set_isOpen: React.Dispatch<React.SetStateAction<boolean>>,
-	connect: (_providerType: number) => Promise<void>,
-	walletType: {[key: string]: number},
-}
-function	ModalLogin({isOpen, set_isOpen, connect, walletType}: TModalLogin): ReactElement {
+function	ModalLogin({isOpen, set_isOpen, connect, walletType}: ModalLoginTypes.TModalLogin): ReactElement {
 	return (
 		<Modal
 			isOpen={isOpen}

--- a/lib/src/components/SearchBox.d.tsx
+++ b/lib/src/components/SearchBox.d.tsx
@@ -1,0 +1,7 @@
+export type TSearchBox = {
+	searchTerm: string;
+	onChange: (s: string) => void;
+	onSearch?: (s: string) => void;
+	isNarrow?: boolean;
+	ariaLabel?: string;
+};

--- a/lib/src/components/SearchBox.tsx
+++ b/lib/src/components/SearchBox.tsx
@@ -1,21 +1,15 @@
 import React, {ReactElement} from 'react';
 import {Card} from './Card';
 import IconSearch from '../icons/IconSearch';
+import type * as SearchBoxTypes	from './SearchBox.d';
 
-type 		TSearchBox = {
-	searchTerm: string,
-	onChange: (s: string) => void
-	onSearch?: (s: string) => void
-	isNarrow?: boolean,
-	ariaLabel?: string
-}
 function	SearchBox({
 	searchTerm,
 	onChange,
 	onSearch,
 	isNarrow,
 	ariaLabel = 'Search'
-}: TSearchBox): ReactElement {
+}: SearchBoxTypes.TSearchBox): ReactElement {
 	return (
 		<Card padding={'none'}>
 			<form

--- a/lib/src/components/StatisticCard.d.tsx
+++ b/lib/src/components/StatisticCard.d.tsx
@@ -1,0 +1,5 @@
+export type TStatisticCard = {
+	label: string;
+	value: string;
+	variant?: 'surface' | 'background';
+} & React.ComponentPropsWithoutRef<'div'>;

--- a/lib/src/components/StatisticCard.tsx
+++ b/lib/src/components/StatisticCard.tsx
@@ -1,12 +1,8 @@
 import	React, {ReactElement} from 'react';
 import	{Card} from './Card';
+import type * as StatisticCardTypes	from './StatisticCard.d';
 
-export type TStatisticCard = {
-	label: string;
-	value: string;
-	variant?: 'surface' | 'background',
-} & React.ComponentPropsWithoutRef<'div'>;
-function StatisticCardBase({label, value, ...props}: TStatisticCard): ReactElement {
+function StatisticCardBase({label, value, ...props}: StatisticCardTypes.TStatisticCard): ReactElement {
 	const	className = props.className || 'col-span-12 md:col-span-4';
 	return (
 		<Card

--- a/lib/src/components/Switch.d.tsx
+++ b/lib/src/components/Switch.d.tsx
@@ -1,0 +1,4 @@
+export type TSwitch = {
+	isEnabled: boolean;
+	onSwitch: React.Dispatch<React.SetStateAction<boolean>>;
+};

--- a/lib/src/components/Switch.tsx
+++ b/lib/src/components/Switch.tsx
@@ -1,13 +1,9 @@
 
 import	React, {ReactElement}		from	'react';
 import	{Switch as HeadlessSwitch}	from	'@headlessui/react';
+import type * as SwitchTypes		from 	'./Switch.d';
 
-export type TSwitch = {
-	isEnabled: boolean;
-	onSwitch: React.Dispatch<React.SetStateAction<boolean>>;
-}
-
-function Switch({isEnabled, onSwitch}: TSwitch): ReactElement {
+function Switch({isEnabled, onSwitch}: SwitchTypes.TSwitch): ReactElement {
 	return (
 		<div>
 			<HeadlessSwitch

--- a/lib/src/components/SwitchTheme.d.tsx
+++ b/lib/src/components/SwitchTheme.d.tsx
@@ -1,0 +1,4 @@
+export type TSwitchTheme = {
+	theme: string;
+	switchTheme: () => void;
+} & React.ComponentPropsWithoutRef<'div'>;

--- a/lib/src/components/SwitchTheme.tsx
+++ b/lib/src/components/SwitchTheme.tsx
@@ -1,14 +1,10 @@
-import	React, {ReactElement}	from	'react';
-import	useClientEffect			from	'../hooks/useClientEffect';
-import	IconThemeDark			from	'../icons/IconThemeDark';
-import	IconThemeLight			from	'../icons/IconThemeLight';
+import	React, {ReactElement}		from	'react';
+import	useClientEffect				from	'../hooks/useClientEffect';
+import	IconThemeDark				from	'../icons/IconThemeDark';
+import	IconThemeLight				from	'../icons/IconThemeLight';
+import type * as SwitchThemeTypes	from 	'./SwitchTheme.d';
 
-type 		TSwitchTheme = {
-	theme: string,
-	switchTheme: () => void,
-} & React.ComponentPropsWithoutRef<'div'>
-
-function	SwitchTheme({theme, switchTheme, ...props}: TSwitchTheme): ReactElement {
+function	SwitchTheme({theme, switchTheme, ...props}: SwitchThemeTypes.TSwitchTheme): ReactElement {
 	const	[currentTheme, set_currentTheme] = React.useState('light');
 
 	useClientEffect((): void => {

--- a/lib/src/components/Table.d.tsx
+++ b/lib/src/components/Table.d.tsx
@@ -1,0 +1,5 @@
+export type TStatisticCard = {
+	label: string;
+	value: string;
+	variant?: 'surface' | 'background';
+} & React.ComponentPropsWithoutRef<'div'>;

--- a/lib/src/components/Table.tsx
+++ b/lib/src/components/Table.tsx
@@ -1,12 +1,8 @@
 import	React, {ReactElement} from 'react';
 import	{Card} from './Card';
+import type * as TableTypes	from './Table.d';
 
-export type TStatisticCard = {
-	label: string;
-	value: string;
-	variant?: 'surface' | 'background',
-} & React.ComponentPropsWithoutRef<'div'>;
-function StatisticCardBase({label, value, ...props}: TStatisticCard): ReactElement {
+function StatisticCardBase({label, value, ...props}: TableTypes.TStatisticCard): ReactElement {
 	const	className = props.className || 'col-span-12 md:col-span-4';
 	return (
 		<Card

--- a/lib/src/components/TokenCard.d.tsx
+++ b/lib/src/components/TokenCard.d.tsx
@@ -1,0 +1,6 @@
+export type TTokenCard = {
+	label: string;
+	value: string;
+	imgSrc: string;
+	onClick?: React.MouseEventHandler;
+} & React.ComponentPropsWithoutRef<'div'>;

--- a/lib/src/components/TokenCard.tsx
+++ b/lib/src/components/TokenCard.tsx
@@ -1,14 +1,9 @@
 import	React, {ReactElement} 	from 'react';
 import	{Card} 					from './Card';
-import	IconChevron				from	'../icons/IconChevron';
+import	IconChevron				from '../icons/IconChevron';
+import type * as TokenCardTypes	from './TokenCard.d';
 
-export type TTokenCard = {
-	label: string;
-	value: string;
-	imgSrc: string;
-	onClick?: React.MouseEventHandler;
-} & React.ComponentPropsWithoutRef<'div'>;
-function TokenCardBase({label, value, imgSrc, onClick, className, ...props}: TTokenCard): ReactElement {
+function TokenCardBase({label, value, imgSrc, onClick, className, ...props}: TokenCardTypes.TTokenCard): ReactElement {
 	const	cardClassname = className || 'col-span-12 sm:col-span-6';
 	return (
 		<Card

--- a/lib/src/components/TxHashWithActions.d.tsx
+++ b/lib/src/components/TxHashWithActions.d.tsx
@@ -1,0 +1,7 @@
+export type TTxHashWithActions = {
+	txHash: string;
+	explorer: string;
+	truncate?: number;
+	wrapperClassName?: string;
+	className?: string;
+};

--- a/lib/src/components/TxHashWithActions.tsx
+++ b/lib/src/components/TxHashWithActions.tsx
@@ -2,21 +2,15 @@ import	React, {ReactElement}			from	'react';
 import	{truncateHex, copyToClipboard}	from	'../utils/utils';
 import	IconLinkOut						from	'../icons/IconLinkOut';
 import	IconCopy						from	'../icons/IconCopy';
+import type * as TxHashWithActionsTypes	from 	'./TxHashWithActions.d';
 
-export type	TTxHashWithActions = {
-	txHash: string,
-	explorer: string,
-	truncate?: number,
-	wrapperClassName?: string
-	className?: string
-};
 function	TxHashWithActions({
 	txHash,
 	explorer = 'https://etherscan.io',
 	truncate = 5,
 	wrapperClassName,
 	className = 'font-mono font-bold text-left text-typo-primary'
-}: TTxHashWithActions): ReactElement {
+}: TxHashWithActionsTypes.TTxHashWithActions): ReactElement {
 	return (
 		<span className={`flex flex-row items-center ${wrapperClassName}`}>
 			<p className={className}>{truncateHex(txHash, truncate)}</p>

--- a/lib/src/components/index.tsx
+++ b/lib/src/components/index.tsx
@@ -40,7 +40,39 @@ export {
 	Banner,
 };
 
-import type * as ModalMenuTypes from './ModalMenu.d';
+import type * as AddressWithActionsTypes from './AddressWithActions.d';
 import type * as AlertTypes from './Alert.d';
+import type * as BannerTypes from './Banner.d';
 import type * as ButtonTypes from './Button.d';
-export type {AlertTypes, ButtonTypes, ModalMenuTypes};
+import type * as CardTypes from './Card.d';
+import type * as DescriptionListTypes from './DescriptionList.d';
+import type * as DropdownTypes from './Dropdown.d';
+import type * as ModalLoginTypes from './ModalLogin.d';
+import type * as ModalMenuTypes from './ModalMenu.d';
+import type * as ModalTypes from './Modal.d';
+import type * as SearchBoxTypes from './SearchBox.d';
+import type * as StatisticCardTypes from './StatisticCard.d';
+import type * as SwitchTypes from './Switch.d';
+import type * as SwitchThemeTypes from './SwitchTheme.d';
+import type * as TableTypes from './Table.d';
+import type * as TokenCardTypes from './TokenCard.d';
+import type * as TxHashWithActionsTypes from './TxHashWithActions.d';
+export type {
+	AddressWithActionsTypes,
+	AlertTypes,
+	BannerTypes,
+	ButtonTypes,
+	CardTypes,
+	DescriptionListTypes,
+	DropdownTypes,
+	ModalLoginTypes,
+	ModalMenuTypes,
+	ModalTypes,
+	SearchBoxTypes,
+	StatisticCardTypes,
+	SwitchTypes,
+	SwitchThemeTypes,
+	TableTypes,
+	TokenCardTypes,
+	TxHashWithActionsTypes,
+};

--- a/lib/src/layouts/Header.tsx
+++ b/lib/src/layouts/Header.tsx
@@ -1,7 +1,8 @@
 import	React, {ReactElement}				from	'react';
 import	useWeb3								from	'../contexts/useWeb3';
 import	{Card}								from	'../components/Card';
-import	{Dropdown, TDropdownOption}			from	'../components/Dropdown';
+import	{Dropdown}							from	'../components/Dropdown';
+import	{TDropdownOption}					from	'../components/Dropdown.d';
 import	{truncateHex}						from	'../utils/utils';
 import	IconNetworkEthereum					from	'../icons/IconNetworkEthereum';
 import	IconNetworkFantom					from	'../icons/IconNetworkFantom';


### PR DESCRIPTION
This PR exports the typings into separate files with the naming convention of `[component].d.tsx`.

The typings are also exported in `components/index.tsx`.

Related issue: #10