### PR TITLE
build: Remove unnecessary out dir and .eslintrc.cjs

### DIFF
--- a/packages/web-lib/package.json
+++ b/packages/web-lib/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yearn-finance/web-lib",
-  "version": "0.15.23",
+  "version": "0.15.26",
   "files": [
     "."
   ],

--- a/packages/web-lib/tsconfig.json
+++ b/packages/web-lib/tsconfig.json
@@ -2,7 +2,6 @@
 	"compilerOptions": {
 		"baseUrl": ".",
 		"rootDirs": ["."],
-		"outDir": "./dist",
 		"paths": {
 			"@yearn-finance/web-lib/components/*": ["components/*"],
 			"@yearn-finance/web-lib/components": ["components"],
@@ -48,7 +47,6 @@
 	},
 	"exclude": ["node_modules"],
 	"include": [
-		".eslintrc.cjs",
 		"components/**/*",
 		"contexts/**/*",
 		"hooks/**/*",


### PR DESCRIPTION
We don't need to explicitly include `.eslintrc.cjs`, and the `outDir` is already specified in the build command, 

```json
"build": "bump && tsc --module es2022 --outDir dist --jsx react",
```

![telegram-cloud-photo-size-5-6316477217202353099-y](https://user-images.githubusercontent.com/78794805/202214428-fb04c941-10b2-4fcd-97da-091f7cd2f504.jpg)
