### PR TITLE
refactor: Take the toast contents in the return fn of `useToast`

### DIFF
--- a/packages/playground/pages/doc/components/toast.tsx
+++ b/packages/playground/pages/doc/components/toast.tsx
@@ -24,54 +24,45 @@ export default function	App(): React.ReactElement {
 }`.trim();
 
 export function ToastComponent(): ReactElement {
-	const successToast = useToast({
-		type: 'success',
-		content: 'Transaction succeed'
-	});
-	const errorToast = useToast({
-		type: 'error',
-		content: 'Transaction failed. Insufficient balance'
-	});
-	const warningToast = useToast({
-		type: 'warning',
-		content: 'Incorrect Network selected. Please change your wallet to Optimism'
-	});
-	const infoToast = useToast({
-		type: 'info',
-		content: 'This is old vault, migrate from here',
-		cta: {label: 'Add +', onClick: (): void => alert('You\'ve clicked the button!')}
-	});
-	const eternalToast = useToast({ type: 'info', content: 'This toast needs to be closed explicitly', duration: Infinity});
+	const toast = useToast();
 	
 	return (
 		<div className={'grid grid-cols-4 gap-4'}>
 			<Button
 				variant={'light'}
-				onClick={successToast}
+				onClick={(): string => toast({type: 'success', content: 'Transaction succeed'})}
 				className={'min-w-[132px]'}>
 				{'Success toast'}
 			</Button>
 			<Button
 				variant={'light'}
-				onClick={errorToast}
+				onClick={(): string => toast({type: 'error', content: 'Transaction failed. Insufficient balance'})}
 				className={'min-w-[132px]'}>
 				{'Error toast'}
 			</Button>
 			<Button
 				variant={'light'}
-				onClick={warningToast}
+				onClick={(): string => toast({type: 'warning', content: 'Incorrect Network selected. Please change your wallet to Optimism'})}
 				className={'min-w-[132px]'}>
 				{'Warning toast'}
 			</Button>
 			<Button
 				variant={'light'}
-				onClick={infoToast}
+				onClick={(): string =>toast({
+					type: 'info',
+					content: 'This is old vault, migrate from here',
+					cta: {label: 'Add +', onClick: (): void => alert('You\'ve clicked the button!')}
+				})}
 				className={'min-w-[132px]'}>
 				{'Info toast'}
 			</Button>
 			<Button
 				variant={'light'}
-				onClick={eternalToast}
+				onClick={(): string => toast({
+					type: 'info',
+					content: 'This toast needs to be closed explicitly',
+					duration: Infinity
+				})}
 				className={'min-w-[132px]'}>
 				{'Eternal toast'}
 			</Button>

--- a/packages/web-lib/hooks/useToast.tsx
+++ b/packages/web-lib/hooks/useToast.tsx
@@ -1,11 +1,12 @@
 import React from 'react';
-import {toast, ToastOptions} from 'react-hot-toast';
+import {toast} from 'react-hot-toast';
 import IconAlertCritical from '@yearn-finance/web-lib/icons/IconAlertCritical';
 import IconAlertError from '@yearn-finance/web-lib/icons/IconAlertError';
 import IconAlertWarning from '@yearn-finance/web-lib/icons/IconAlertWarning';
 import IconCheckmark from '@yearn-finance/web-lib/icons/IconCheckmark';
 
 import type {ReactElement} from 'react';
+import type {ToastOptions} from 'react-hot-toast';
 
 type TCTA = {
 	label: string;
@@ -27,46 +28,48 @@ function buildMessage({content, cta}: Pick<TUseToast, 'content' | 'cta'>): React
 	);
 }
 
-export function useToast({content, type, cta, ...toastOptions}: TUseToast): () => string {
-	const message = cta ? buildMessage({content, cta}) : content;
+export function useToast(): (props: TUseToast) => string {
+	return ({content, type, cta, ...toastOptions}: TUseToast): string => {
+		const message = cta ? buildMessage({content, cta}) : content;
 
-	switch (type) {
-	case 'error':
-		return (): string => toast(message, {
-			icon: <IconAlertCritical className={'ml-3'} />,
-			style: {
-				backgroundColor: '#C73203',
-				color: 'white'
-			},
-			...toastOptions
-		});
-	case 'warning':
-		return (): string => toast(message, {
-			icon: <IconAlertWarning className={'ml-3'} />,
-			style: {
-				backgroundColor: '#FFDC53'
-			},
-			...toastOptions
-		});
-	case 'success':
-		return (): string => toast(message, {
-			icon: <IconCheckmark className={'ml-3'} />,
-			style: {
-				backgroundColor: '#00796D',
-				color: 'white'
-			},
-			...toastOptions
-		});
-	case 'info':
-		return (): string => toast(message, {
-			icon: <IconAlertError className={'ml-3'} />,
-			style: {
-				backgroundColor: '#0657F9',
-				color: 'white'
-			},
-			...toastOptions
-		});
-	default:
-		return (): string => toast.success(content);
-	}
+		switch (type) {
+		case 'error':
+			return toast(message, {
+				icon: <IconAlertCritical className={'ml-3'} />,
+				style: {
+					backgroundColor: '#C73203',
+					color: 'white'
+				},
+				...toastOptions
+			});
+		case 'warning':
+			return toast(message, {
+				icon: <IconAlertWarning className={'ml-3'} />,
+				style: {
+					backgroundColor: '#FFDC53'
+				},
+				...toastOptions
+			});
+		case 'success':
+			return toast(message, {
+				icon: <IconCheckmark className={'ml-3'} />,
+				style: {
+					backgroundColor: '#00796D',
+					color: 'white'
+				},
+				...toastOptions
+			});
+		case 'info':
+			return toast(message, {
+				icon: <IconAlertError className={'ml-3'} />,
+				style: {
+					backgroundColor: '#0657F9',
+					color: 'white'
+				},
+				...toastOptions
+			});
+		default:
+			return toast.success(content);
+		}
+	};
 }


### PR DESCRIPTION
Pass contents of the toast to the `toast` function, rather than initialise when the hook is created