### PR TITLE
feat: Add `isTAddress` type guard

### DIFF
--- a/packages/web-lib/utils/isTAddress.test.ts
+++ b/packages/web-lib/utils/isTAddress.test.ts
@@ -1,0 +1,25 @@
+import { isTAddress } from "./isTAddress";
+
+describe("isTAddress", () => {
+	it("should return true for a valid TAddress", () => {
+		const tAddress = "0xabcdef0123456789";
+		expect(isTAddress(tAddress)).toBe(true);
+	});
+
+	it("should return false for an invalid TAddress", () => {
+		const tAddress = "abcdef0123456789";
+		expect(isTAddress(tAddress)).toBe(false);
+	});
+
+	it("should return false for an empty string", () => {
+		expect(isTAddress("")).toBe(false);
+	});
+
+	it("should return false for a null value", () => {
+		expect(isTAddress(null)).toBe(false);
+	});
+
+	it("should return false for an undefined value", () => {
+		expect(isTAddress(undefined)).toBe(false);
+	});
+});

--- a/packages/web-lib/utils/isTAddress.ts
+++ b/packages/web-lib/utils/isTAddress.ts
@@ -1,0 +1,6 @@
+import { TAddress } from "./address";
+
+export function isTAddress(address?: string | null): address is TAddress {
+	const regex = /^0x([0-9a-f][0-9a-f])*$/i;
+	return !!address && regex.test(address);
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Add `isTAddress` type guard

## Related Issue

<!--- Please link to the issue here -->

https://github.com/yearn/yearn.fi/pull/29#discussion_r1064538622

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Very useful to make sure we do not use invalid addresses

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

https://github.com/yearn/web-lib/compare/feat/isTAddress?expand=1#diff-ea59a70f338db16955b8c7d36078f7bda2348672f2a4b966212c8dde3471f8b3