### PR TITLE
feat: Implement the `useExplorer` hook

### DIFF
--- a/packages/web-lib/hooks/useExplorer.tsx
+++ b/packages/web-lib/hooks/useExplorer.tsx
@@ -1,0 +1,13 @@
+import {chains} from '@yearn-finance/web-lib/utils/web3/chains';
+import { useMemo } from 'react';
+import { useChainID } from './useChainID';
+
+/* 🔵 - Yearn Finance ******************************************************
+** This hook can be used to grab the explorer of the current network.
+** It will return the address of the network explorer.
+**************************************************************************/
+export function useExplorer(): string {
+	const {safeChainID} = useChainID();
+
+	return useMemo(() => chains[safeChainID].block_explorer, [safeChainID])
+}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

* Implement the `useExplorer` hook

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/web-lib/issues/127

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Easier way to get the explorer of the current network

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and tried it out in the playground
