### PR TITLE
feat: Export `address` as `TAddress`

### DIFF
--- a/packages/web-lib/contexts/types.ts
+++ b/packages/web-lib/contexts/types.ts
@@ -64,7 +64,7 @@ export type TWeb3Options = {
 }
 
 export type TWeb3Context = {
-	address: string | null | undefined,
+	address: TAddress | undefined,
 	ens: string | undefined,
 	chainID: number,
 	isDisconnected: boolean,

--- a/packages/web-lib/contexts/useWeb3.tsx
+++ b/packages/web-lib/contexts/useWeb3.tsx
@@ -22,6 +22,7 @@ import type {ErrorInfo, ReactElement} from 'react';
 import type {TPartnersInfo} from '@yearn-finance/web-lib/utils/partners';
 import type {Provider} from '@web3-react/types';
 import type {TWeb3Context, TWeb3Options} from './types';
+import { isTAddress } from '../utils/isTAddress';
 
 const defaultState = {
 	address: undefined,
@@ -419,6 +420,11 @@ export const Web3ContextApp = ({
 	******************************************************************************************/
 	const	contextValue = useMemo((): TWeb3Context => {
 		const	isReallyActive = isActive && (web3Options?.supportedChainID || defaultOptions.supportedChainID || []).includes(Number(chainId || 0));
+
+		if (!isTAddress(account)) {
+			throw new Error(`Invalid address: ${account}`)
+		}
+		
 		return ({
 			address: account,
 			ens: isReallyActive ? ens : '',


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Export `address` as `TAddress` so it's type safe, we could then go a step further and validate that the address is actually valid, but as we are using `useWeb3React()` it should be.

## Related Issue

<!--- Please link to the issue here -->

https://github.com/yearn/yearn.fi/pull/29/files#r1064882469

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Type safety

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally

## Screenshots (if appropriate):
