### PR TITLE
fix: Expose modal login error message

### DIFF
--- a/packages/web-lib/components/ModalLogin.tsx
+++ b/packages/web-lib/components/ModalLogin.tsx
@@ -29,7 +29,7 @@ function ModalLogin(props: TModalLogin): ReactElement {
 					onClick={(): void => {
 						onConnect(
 							'INJECTED',
-							(): string => toast({content: 'Unsupported network. Please use Ethereum mainnet.', type: 'error'}),
+							(error): string => toast({content: error.message ?? 'Unsupported network. Please use Ethereum mainnet.', type: 'error'}),
 							(): void => onClose()
 						);
 					}}
@@ -41,7 +41,7 @@ function ModalLogin(props: TModalLogin): ReactElement {
 					onClick={(): void => {
 						onConnect(
 							'WALLET_CONNECT',
-							(): string => toast({content: 'Invalid chain', type: 'error'}),
+							(error): string => toast({content: error.message ?? 'Invalid chain', type: 'error'}),
 							(): void => onClose()
 						);
 					}}
@@ -53,7 +53,7 @@ function ModalLogin(props: TModalLogin): ReactElement {
 					onClick={(): void => {
 						onConnect(
 							'EMBED_COINBASE',
-							(): string => toast({content: 'Invalid chain', type: 'error'}),
+							(error): string => toast({content: error.message ??'Invalid chain', type: 'error'}),
 							(): void => onClose()
 						);
 					}}
@@ -65,7 +65,7 @@ function ModalLogin(props: TModalLogin): ReactElement {
 					onClick={(): void => {
 						onConnect(
 							'EMBED_GNOSIS_SAFE',
-							(): string => toast({content: 'Invalid chain', type: 'error'}),
+							(error): string => toast({content: error.message ?? 'Invalid chain', type: 'error'}),
 							(): void => onClose()
 						);
 					}}


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Expose the correct error message

## Related Issue

<!--- Please link to the issue here -->

Fixes https://github.com/yearn/web-lib/issues/193

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

When an error happens in the modal login, we're just having a toast with the error message "Invalid chain" which is not accurate, we should be exposing the actual error so it's easier to debug

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

Ran locally and tried it out

## Screenshots (if appropriate):

<img width="1582" alt="Screenshot 2023-03-03 at 9 53 41" src="https://user-images.githubusercontent.com/78794805/222663810-3ebc2b8c-a138-4933-b437-6163034b1125.png">
