### PR TITLE
refactor: Format value utils and add tests

### DIFF
--- a/packages/web-lib/utils/format.value.test.ts
+++ b/packages/web-lib/utils/format.value.test.ts
@@ -1,0 +1,25 @@
+import {formatCounterValue, formatCounterValueRaw} from './format.value';
+
+describe('counterValue and counterValueRaw', (): void => {
+	test('returns $0,00 and empty string when amount or price are missing', (): void => {
+		expect(formatCounterValue(0, 100)).toBe('$0,00');
+		expect(formatCounterValue(100, 0)).toBe('$0,00');
+		expect(formatCounterValueRaw(0, 100)).toBe('');
+		expect(formatCounterValueRaw(100, 0)).toBe('');
+	});
+
+	test('returns correct formatted counter value with two decimal places when value is less than or equal to 10000', (): void => {
+		expect(formatCounterValue(10, 100)).toBe('$1 000,00');
+		expect(formatCounterValueRaw(10, 100)).toBe('1 000,00');
+	});
+
+	test('returns correct formatted counter value without decimal places when value is greater than 10000', (): void => {
+		expect(formatCounterValue(200, 100)).toBe('$20 000');
+		expect(formatCounterValueRaw(200, 100)).toBe('20 000');
+	});
+
+	test('handles invalid input strings', (): void => {
+		expect(formatCounterValue('invalid', 100)).toBe('$0,00');
+		expect(formatCounterValueRaw('invalid', 100)).toBe('0,00');
+	});
+});

--- a/packages/web-lib/utils/format.value.ts
+++ b/packages/web-lib/utils/format.value.ts
@@ -2,8 +2,9 @@ import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 
 export function	counterValue(amount: number | string, price: number): string {
 	if (!amount || !price) {
-		return ('$0.00');
+		return ('$0,00');
 	}
+
 	const value = (Number(amount) || 0) * (price || 0);
 	if (value > 10000) {
 		return (`$${formatAmount(value, 0, 0)}`);


### PR DESCRIPTION
* Refactor the return value to be `$0,00` rather than `$0.00` -- this will fix the hydration problem we were getting in the frontend
* Add tests to the format value functions