### PR TITLE
feat: add optimism staking rewards constants

### DIFF
--- a/packages/web-lib/utils/constants.ts
+++ b/packages/web-lib/utils/constants.ts
@@ -43,4 +43,6 @@ export const VEYFI_POSITION_HELPER_ADDRESS = toAddress('0x5A70cD937bA3Daec8188E9
 export const SOLVER_COW_VAULT_RELAYER_ADDRESS = toAddress('0xC92E8bdf79f0507f65a392b0ab4667716BFE0110');
 export const SOLVER_WIDO_RELAYER_ADDRESS = toAddress('0x7Fb69e8fb1525ceEc03783FFd8a317bafbDfD394');
 
-
+// Optimism staking rewards contract addresses used on yVault app
+export const STAKING_REWARDS_REGISTRY_ADDRESS = toAddress('0x8ED9F6343f057870F1DeF47AaE7CD88dfAA049A8');
+export const STAKING_REWARDS_ZAP_ADDRESS = toAddress('0xd155F5bF8a475007Fa369e6314C3673e4Bb1e292');


### PR DESCRIPTION
## Description

- Add contract addresses needed for the Optimism staking rewards use case on yVault app

## Related Issue

deployment: https://github.com/yearn/yearn-strategies/issues/475#issuecomment-1495139236

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Constants will be imported by web apps that implement staking rewards use case