### PR TITLE
fix: parseMarkdown strikethrough

### DIFF
--- a/packages/web-lib/utils/helpers.tsx
+++ b/packages/web-lib/utils/helpers.tsx
@@ -8,7 +8,7 @@ import {yToast} from '@yearn-finance/web-lib/components/yToast';
 export function	parseMarkdown(markdownText: string): string {
 	const htmlText = markdownText
 		.replace(/\[(.*?)\]\((.*?)\)/gim, "<a class='link' target='_blank' href='$2'>$1</a>")
-		.replace(/~~(.*?)~~/gim, "<span class='text-primary-500'>$1</span>")
+		.replace(/~~(.*?)~~/gim, "<span class='line-through'>$1</span>")
 		.replace(/\*\*(.*?)\*\*/gim, "<span class='font-bold'>$1</span>")
 		;
 


### PR DESCRIPTION
~~ is for ~~strikethrough~~, per https://www.markdownguide.org/extended-syntax/#strikethrough

Or maybe yearn meta treats ~~ differently?

## How Has This Been Tested?

I tested something similar locally, but didn't actually test this with the web-lib. Fwiw, `line-through` is the Tailwind class for strikethrough, https://tailwindcss.com/docs/text-decoration.


