### PR TITLE
feat: Add ellipsis to big numbers

### DIFF
--- a/packages/web-lib/package.json
+++ b/packages/web-lib/package.json
@@ -72,7 +72,7 @@
     "eslint-plugin-simple-import-sort": "^10.0.0",
     "eslint-plugin-tailwindcss": "^3.9.0",
     "eslint-plugin-unused-imports": "^2.0.0",
-    "jest": "29.4.3",
+    "jest": "^29.5.0",
     "postcss": "^8.4.21",
     "postcss-import": "^15.1.0",
     "postcss-nesting": "^11.2.1",

--- a/packages/web-lib/utils/format.number.test.ts
+++ b/packages/web-lib/utils/format.number.test.ts
@@ -1,0 +1,53 @@
+import {amount} from './format.number';
+
+describe('amount', (): void => {
+	beforeAll((): void => {
+		// Mock the navigator to avoid environment inconsistencies
+		Object.defineProperty(global, 'navigator', {
+			value: {
+				language: 'fr-FR'
+			},
+			configurable: true
+		});
+	});
+
+	it('should format number correctly with default parameters', (): void => {
+		expect(amount(1234.56)).toBe('1 234,56');
+	});
+
+	it('should format string number correctly with default parameters', (): void => {
+		expect(amount('1234.56')).toBe('1 234,56');
+	});
+
+	it('should format number with custom minimum and maximum fraction digits', (): void => {
+		expect(amount(1234.5678, 3, 4)).toBe('1 234,5678');
+	});
+
+	it('should handle maximumFractionDigits less than minimumFractionDigits', (): void => {
+		expect(amount(1234.56, 3, 1)).toBe('1 234,560');
+	});
+
+	it('should format number with ellipsis in the middle', (): void => {
+		expect(amount(12345678912345678, 0, 0, 12)).toBe('12 345...45 678');
+	});
+
+	it('should format number with decimal part and ellipsis in the middle', (): void => {
+		expect(amount(123451234567.6789, 2, 2, 10)).toBe('123 4...67,68');
+	});
+
+	it('should not apply ellipsis if displayDigits is larger than the formatted amount length', (): void => {
+		expect(amount(121234567834.56, 2, 2, 20)).toBe('121 234 567 834,56');
+	});
+
+	it('should not apply ellipsis if displayDigits is not provided', (): void => {
+		expect(amount(1234123456756789, 0, 0)).toBe('1 234 123 456 756 789');
+	});
+
+	it('should handle non-numeric input as 0', (): void => {
+		expect(amount('not-a-number')).toBe('0,00');
+	});
+
+	it('should handle NaN input as 0', (): void => {
+		expect(amount(NaN)).toBe('0,00');
+	});
+});

--- a/packages/web-lib/utils/format.number.ts
+++ b/packages/web-lib/utils/format.number.ts
@@ -2,7 +2,7 @@
 ** Bunch of function using the power of the browsers and standard functions
 ** to correctly format numbers, currency and date
 **************************************************************************/
-export function	amount(amount: number | string, minimumFractionDigits = 2, maximumFractionDigits = 2): string {
+export function	amount(amount: number | string, minimumFractionDigits = 2, maximumFractionDigits = 2, displayDigits = 0): string {
 	let		locale = 'fr-FR';
 	if (typeof(navigator) !== 'undefined') {
 		locale = navigator.language || 'fr-FR';
@@ -19,7 +19,15 @@ export function	amount(amount: number | string, minimumFractionDigits = 2, maxim
 	if (isNaN(amount)) {
 		amount = 0;
 	}
-	return (new Intl.NumberFormat([locale, 'en-US'], {minimumFractionDigits, maximumFractionDigits}).format(amount));
+	let formattedAmount = new Intl.NumberFormat([locale, 'en-US'], {minimumFractionDigits, maximumFractionDigits}).format(amount);
+	
+	if (displayDigits && displayDigits > 0 && formattedAmount.length > displayDigits) {
+		const leftSide = formattedAmount.slice(0, Math.ceil(displayDigits / 2));
+		const rightSide = formattedAmount.slice(-Math.floor(displayDigits / 2));
+		formattedAmount = `${leftSide}...${rightSide}`;
+	}
+	
+	return formattedAmount;
 }
 
 export function	currency(amount: number, decimals = 2): string {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1001,7 +1001,7 @@
     jest-util "^29.5.0"
     slash "^3.0.0"
 
-"@jest/core@^29.4.3", "@jest/core@^29.5.0":
+"@jest/core@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/core/-/core-29.5.0.tgz#76674b96904484e8214614d17261cc491e5f1f03"
   integrity sha512-28UzQc7ulUrOQw1IsN/kv1QES3q2kkbl/wGslyhAclqZ/8cMdB5M68BffkIdSJgKBUt50d3hbwJ92XESlE7LiQ==
@@ -1195,7 +1195,7 @@
     "@types/yargs" "^17.0.8"
     chalk "^4.0.0"
 
-"@jest/types@^29.4.3", "@jest/types@^29.5.0":
+"@jest/types@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.5.0.tgz#f59ef9b031ced83047c67032700d8c807d6e1593"
   integrity sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==
@@ -7045,7 +7045,7 @@ jest-circus@^29.5.0:
     slash "^3.0.0"
     stack-utils "^2.0.3"
 
-jest-cli@^29.4.3:
+jest-cli@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-cli/-/jest-cli-29.5.0.tgz#b34c20a6d35968f3ee47a7437ff8e53e086b4a67"
   integrity sha512-L1KcP1l4HtfwdxXNFCL5bmUbLQiKrakMUriBEcc1Vfz6gx31ORKdreuWvmQVBit+1ss9NNR3yxjwfwzZNdQXJw==
@@ -7414,15 +7414,15 @@ jest-worker@^29.5.0:
     merge-stream "^2.0.0"
     supports-color "^8.0.0"
 
-jest@29.4.3:
-  version "29.4.3"
-  resolved "https://registry.yarnpkg.com/jest/-/jest-29.4.3.tgz#1b8be541666c6feb99990fd98adac4737e6e6386"
-  integrity sha512-XvK65feuEFGZT8OO0fB/QAQS+LGHvQpaadkH5p47/j3Ocqq3xf2pK9R+G0GzgfuhXVxEv76qCOOcMb5efLk6PA==
+jest@^29.5.0:
+  version "29.5.0"
+  resolved "https://registry.yarnpkg.com/jest/-/jest-29.5.0.tgz#f75157622f5ce7ad53028f2f8888ab53e1f1f24e"
+  integrity sha512-juMg3he2uru1QoXX078zTa7pO85QyB9xajZc6bU+d9yEGwrKX6+vGmJQ3UdVZsvTEUARIdObzH68QItim6OSSQ==
   dependencies:
-    "@jest/core" "^29.4.3"
-    "@jest/types" "^29.4.3"
+    "@jest/core" "^29.5.0"
+    "@jest/types" "^29.5.0"
     import-local "^3.0.2"
-    jest-cli "^29.4.3"
+    jest-cli "^29.5.0"
 
 joycon@^3.0.1:
   version "3.1.1"


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Follow up on https://github.com/yearn/macarena-finance/pull/23#issuecomment-1524731052, the discussion came to the conclusion that for big numbers we could use ellipsis in the middle.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Big numbers break the layout, so we need a way to display them more consisely.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

With `packages/web-lib/utils/format.number.test.ts`
