### PR TITLE
feat: New endpoint for mainnet graph uri

### DIFF
--- a/packages/web-lib/contexts/useSettings.tsx
+++ b/packages/web-lib/contexts/useSettings.tsx
@@ -17,7 +17,7 @@ const	defaultSettings = {
 const	defaultNetworks = {
 	1: {
 		rpcURI: getRPC(1),
-		graphURI: 'https://api.thegraph.com/subgraphs/name/0xkofee/yearn-vaults-v2',
+		graphURI: 'https://api.thegraph.com/subgraphs/name/rareweasel/yearn-vaults-v2-subgraph-mainnet',
 		yDaemonURI: `${defaultSettings.yDaemonBaseURI}/1`,
 		metaURI: `${defaultSettings.metaBaseURI}/api/1`,
 		apiURI: `${defaultSettings.apiBaseURI}/v1/chains/1`,


### PR DESCRIPTION
The old end point was erroing

```
{
  "errors": [
    "{\n  \"errors\": [\n    {\n      \"message\": \"indexing_error\"\n    }\n  ]\n}"
  ]
}
```