### PR TITLE
fix: Unable to clear input

### DIFF
--- a/packages/web-lib/utils/format.bigNumber.tsx
+++ b/packages/web-lib/utils/format.bigNumber.tsx
@@ -5,7 +5,7 @@ import type {BigNumberish} from 'ethers';
 
 export type	TNormalizedBN = {
 	raw: BigNumber,
-	normalized: number | string,
+	normalized: number | string | '',
 }
 
 export const {Zero} = ethers.constants;

--- a/packages/web-lib/utils/handlers/handleInputChangeEventValue.test.ts
+++ b/packages/web-lib/utils/handlers/handleInputChangeEventValue.test.ts
@@ -33,10 +33,10 @@ describe('handleInputChangeEventValue', (): void => {
 		expect(normalized).toBe('10.123456');
 	});
 
-	it('returns 0 for empty input', (): void => {
+	it('returns raw Zero and normalized empty string for empty input', (): void => {
 		const {raw, normalized} = handleInputChangeEventValue('', 18);
 		expect(raw.toString()).toBe('0');
-		expect(normalized).toBe('0');
+		expect(normalized).toBe('');
 	});
 
 	it('replaces comma with period in input value', (): void => {

--- a/packages/web-lib/utils/handlers/handleInputChangeEventValue.ts
+++ b/packages/web-lib/utils/handlers/handleInputChangeEventValue.ts
@@ -1,8 +1,12 @@
-import {ethers} from 'ethers';
+import {constants, ethers} from 'ethers';
 
 import type {TNormalizedBN} from '../format';
 
 export function handleInputChangeEventValue(value: string, decimals?: number): TNormalizedBN {
+	if (value === '') {
+		return {raw: constants.Zero, normalized: ''};
+	}
+
 	let		amount = value.replace(/,/g, '.').replace(/[^0-9.]/g, '');
 	const	amountParts = amount.split('.');
 


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

Return an empty string as normalized  when the value of the input field is empty string

## Related Issue

<!--- Please link to the issue here -->

Fix https://github.com/yearn/yearn.fi/issues/181

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Ability to clear the input field so that users can clear it before tying an amount

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

`yarn link` the library to yearn.fi -- was able to clear the input field

## Screenshots (if appropriate):

<img width="552" alt="Screenshot 2023-05-19 at 9 09 18" src="https://github.com/yearn/web-lib/assets/78794805/23b32a74-d1c3-47c8-b888-0fd9ee6bdf4c">

