### PR TITLE
feat: Implement `formatBigNumberOver10K` and `formatNumberOver10K`

### DIFF
--- a/packages/web-lib/utils/format.bigNumber.test.ts
+++ b/packages/web-lib/utils/format.bigNumber.test.ts
@@ -1,27 +1,52 @@
-import {toNormalizedBN} from './format.bigNumber';
+import {formatBigNumberOver10K, toNormalizedBN} from './format.bigNumber';
 
-describe('toNormalizedBN', (): void => {
-	it('returns correct normalized and raw values for input with 0 decimals', (): void => {
-		const {raw, normalized} = toNormalizedBN('1', 0);
-		expect(raw.toString()).toBe('1');
-		expect(normalized).toBe(1);
+describe('format.bigNumber', (): void => {
+	describe('toNormalizedBN()', (): void => {
+		it('returns correct normalized and raw values for input with 0 decimals', (): void => {
+			const {raw, normalized} = toNormalizedBN('1', 0);
+			expect(raw.toString()).toBe('1');
+			expect(normalized).toBe(1);
+		});
+	
+		it('returns correct normalized and raw values for input', (): void => {
+			const {raw, normalized} = toNormalizedBN('1012300000000000000', 18);
+			expect(raw.toString()).toBe('1012300000000000000');
+			expect(normalized).toBe(1.0123);
+		});
+	
+		it('uses default number of decimals (18) when none is specified', (): void => {
+			const {raw, normalized} = toNormalizedBN('1012300000000000000');
+			expect(raw.toString()).toBe('1012300000000000000');
+			expect(normalized).toBe(1.0123);
+		});
+	
+		it('returns correct normalized and raw values for input of 0', (): void => {
+			const {raw, normalized} = toNormalizedBN('0', 18);
+			expect(raw.toString()).toBe('0');
+			expect(normalized).toBe(0);
+		});
 	});
 
-	it('returns correct normalized and raw values for input', (): void => {
-		const {raw, normalized} = toNormalizedBN('1012300000000000000', 18);
-		expect(raw.toString()).toBe('1012300000000000000');
-		expect(normalized).toBe(1.0123);
-	});
+	describe('formatBigNumberOver10K()', (): void => {
+		it('formats big numbers over 10K without decimal points', (): void => {
+			const bigNum = BigInt(10001) * BigInt(Math.pow(10, 18));
+			console.log(bigNum);
+			
+			expect(formatBigNumberOver10K(bigNum)).toBe('10 001');
+		});
 
-	it('uses default number of decimals (18) when none is specified', (): void => {
-		const {raw, normalized} = toNormalizedBN('1012300000000000000');
-		expect(raw.toString()).toBe('1012300000000000000');
-		expect(normalized).toBe(1.0123);
-	});
+		it('formats big numbers equal to 10K with decimal points', (): void => {
+			const bigNum = BigInt(10000) * BigInt(Math.pow(10, 18));
+			expect(formatBigNumberOver10K(bigNum)).toBe('10 000,00');
+		});
 
-	it('returns correct normalized and raw values for input of 0', (): void => {
-		const {raw, normalized} = toNormalizedBN('0', 18);
-		expect(raw.toString()).toBe('0');
-		expect(normalized).toBe(0);
+		it('formats big numbers less than 10K with decimal points', (): void => {
+			const bigNum = BigInt(9999) * BigInt(Math.pow(10, 18));
+			expect(formatBigNumberOver10K(bigNum)).toBe('9 999,00');
+		});
+
+		it('returns 0,00 for 0n', (): void => {
+			expect(formatBigNumberOver10K(0n)).toBe('0,00');
+		});
 	});
 });

--- a/packages/web-lib/utils/format.bigNumber.ts
+++ b/packages/web-lib/utils/format.bigNumber.ts
@@ -69,6 +69,13 @@ export function	parseUnits(value: TNumberish, decimals = 18): bigint {
 	return vParseUnits(`${valueAsNumber}`, decimals);
 }
 
+export const formatBigNumberOver10K = (value: bigint): string => {
+	if (toBigInt(value) > (toBigInt(10000) * toBigInt(1e18))) {
+		return formatAmount(toNormalizedValue(toBigInt(value), 18), 0, 0) ?? '';
+	}
+	return formatAmount(toNormalizedValue(toBigInt(value), 18)) ?? '';
+};
+
 export {toNormalizedAmount as formatToNormalizedAmount};
 export {toNormalizedValue as formatToNormalizedValue};
 export {toNormalizedBN as formatToNormalizedBN};

--- a/packages/web-lib/utils/format.number.test.ts
+++ b/packages/web-lib/utils/format.number.test.ts
@@ -1,53 +1,77 @@
-import {amount} from './format.number';
+import {amount, formatNumberOver10K} from './format.number';
 
-describe('amount', (): void => {
-	beforeAll((): void => {
-		// Mock the navigator to avoid environment inconsistencies
-		Object.defineProperty(global, 'navigator', {
-			value: {
-				language: 'fr-FR'
-			},
-			configurable: true
+describe('format.number', (): void => {
+	describe('amount()', (): void => {
+		beforeAll((): void => {
+			// Mock the navigator to avoid environment inconsistencies
+			Object.defineProperty(global, 'navigator', {
+				value: {
+					language: 'fr-FR'
+				},
+				configurable: true
+			});
+		});
+
+		it('should format number correctly with default parameters', (): void => {
+			expect(amount(1234.56)).toBe('1 234,56');
+		});
+
+		it('should format string number correctly with default parameters', (): void => {
+			expect(amount('1234.56')).toBe('1 234,56');
+		});
+
+		it('should format number with custom minimum and maximum fraction digits', (): void => {
+			expect(amount(1234.5678, 3, 4)).toBe('1 234,5678');
+		});
+
+		it('should handle maximumFractionDigits less than minimumFractionDigits', (): void => {
+			expect(amount(1234.56, 3, 1)).toBe('1 234,560');
+		});
+
+		it('should format number with ellipsis in the middle', (): void => {
+			expect(amount(12345678912345678, 0, 0, 12)).toBe('12 345...45 678');
+		});
+
+		it('should format number with decimal part and ellipsis in the middle', (): void => {
+			expect(amount(123451234567.6789, 2, 2, 10)).toBe('123 4...67,68');
+		});
+
+		it('should not apply ellipsis if displayDigits is larger than the formatted amount length', (): void => {
+			expect(amount(121234567834.56, 2, 2, 20)).toBe(
+				'121 234 567 834,56'
+			);
+		});
+
+		it('should not apply ellipsis if displayDigits is not provided', (): void => {
+			expect(amount(1234123456756789, 0, 0)).toBe(
+				'1 234 123 456 756 789'
+			);
+		});
+
+		it('should handle non-numeric input as 0', (): void => {
+			expect(amount('not-a-number')).toBe('0,00');
+		});
+
+		it('should handle NaN input as 0', (): void => {
+			expect(amount(NaN)).toBe('0,00');
 		});
 	});
 
-	it('should format number correctly with default parameters', (): void => {
-		expect(amount(1234.56)).toBe('1 234,56');
-	});
+	describe('formatNumberOver10K()', (): void => {
+		it('formats numbers over 10K without decimal points', (): void => {
+			expect(formatNumberOver10K(10001)).toBe('10 001');
+		});
 
-	it('should format string number correctly with default parameters', (): void => {
-		expect(amount('1234.56')).toBe('1 234,56');
-	});
+		it('formats numbers equal to 10K without decimal points', (): void => {
+			expect(formatNumberOver10K(10000)).toBe('10 000');
+		});
 
-	it('should format number with custom minimum and maximum fraction digits', (): void => {
-		expect(amount(1234.5678, 3, 4)).toBe('1 234,5678');
-	});
+		it('formats numbers less than 10K with decimal points', (): void => {
+			expect(formatNumberOver10K(9999)).toBe('9 999,00');
+		});
 
-	it('should handle maximumFractionDigits less than minimumFractionDigits', (): void => {
-		expect(amount(1234.56, 3, 1)).toBe('1 234,560');
-	});
-
-	it('should format number with ellipsis in the middle', (): void => {
-		expect(amount(12345678912345678, 0, 0, 12)).toBe('12 345...45 678');
-	});
-
-	it('should format number with decimal part and ellipsis in the middle', (): void => {
-		expect(amount(123451234567.6789, 2, 2, 10)).toBe('123 4...67,68');
-	});
-
-	it('should not apply ellipsis if displayDigits is larger than the formatted amount length', (): void => {
-		expect(amount(121234567834.56, 2, 2, 20)).toBe('121 234 567 834,56');
-	});
-
-	it('should not apply ellipsis if displayDigits is not provided', (): void => {
-		expect(amount(1234123456756789, 0, 0)).toBe('1 234 123 456 756 789');
-	});
-
-	it('should handle non-numeric input as 0', (): void => {
-		expect(amount('not-a-number')).toBe('0,00');
-	});
-
-	it('should handle NaN input as 0', (): void => {
-		expect(amount(NaN)).toBe('0,00');
+		it('returns empty string for 0', (): void => {
+			expect(formatNumberOver10K(0)).toBe('0,00');
+		});
 	});
 });

--- a/packages/web-lib/utils/format.number.ts
+++ b/packages/web-lib/utils/format.number.ts
@@ -71,6 +71,13 @@ export const formatPercent = (n: number, min = 2, max = 2, upperLimit = 500): st
 	return `${amount(safeN || 0, min, max)}%`;
 };
 
+export const formatNumberOver10K = (n: number): string => {
+	if (n >= 10000) {
+		return amount(n, 0, 0) ?? '';
+	}
+	return amount(n) ?? '';
+};
+
 export {amount as formatAmount};
 export {currency as formatCurrency};
 export {withUnit as formatWithUnit};

--- a/packages/web-lib/utils/isZero.ts
+++ b/packages/web-lib/utils/isZero.ts
@@ -5,10 +5,10 @@ export function isZero(value?: TProps): boolean {
 		return false;
 	}
 
-	if (typeof value === "string") {
+	if (typeof value === 'string') {
 		value = value.trim().replace(',', '.');
 
-		if (value === "") {
+		if (value === '') {
 			return false;
 		}
 


### PR DESCRIPTION
## Description

`formatBigNumberOver10K` and `formatNumberOver10K`

## Related Issue

<!--- Please link to the issue here -->

Closes https://github.com/yearn/web-lib/issues/256

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Helpers to deal with (big)numbers higher than 10k

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

* utils/format.bigNumber.test.ts
* utils/format.number.test.ts