### PR TITLE
feat(format.number): Add support to small numbers

### DIFF
--- a/packages/web-lib/utils/format.bigNumber.test.ts
+++ b/packages/web-lib/utils/format.bigNumber.test.ts
@@ -30,8 +30,6 @@ describe('format.bigNumber', (): void => {
 	describe('formatBigNumberOver10K()', (): void => {
 		it('formats big numbers over 10K without decimal points', (): void => {
 			const bigNum = BigInt(10001) * BigInt(Math.pow(10, 18));
-			console.log(bigNum);
-			
 			expect(formatBigNumberOver10K(bigNum)).toBe('10 001');
 		});
 

--- a/packages/web-lib/utils/format.bigNumber.ts
+++ b/packages/web-lib/utils/format.bigNumber.ts
@@ -56,7 +56,7 @@ export	const	toNormalizedValue = (v: bigint, d?: number): number => {
 };
 
 export const	toNormalizedAmount = (v: bigint, d?: number): string => {
-	return formatAmount(toNormalizedValue(v, d ?? 18), 6, 6);
+	return formatAmount({amount: toNormalizedValue(v, d ?? 18), fractionDigits: {min: 6, max: 6}});
 };
 
 export const	toNormalizedBN = (value: TNumberish, decimals?: number): TNormalizedBN => ({
@@ -71,9 +71,9 @@ export function	parseUnits(value: TNumberish, decimals = 18): bigint {
 
 export const formatBigNumberOver10K = (value: bigint): string => {
 	if (toBigInt(value) > (toBigInt(10000) * toBigInt(1e18))) {
-		return formatAmount(toNormalizedValue(toBigInt(value), 18), 0, 0) ?? '';
+		return formatAmount({amount: toNormalizedValue(toBigInt(value), 18), fractionDigits: {min: 0, max: 0}}) ?? '';
 	}
-	return formatAmount(toNormalizedValue(toBigInt(value), 18)) ?? '';
+	return formatAmount({amount: toNormalizedValue(toBigInt(value), 18)}) ?? '';
 };
 
 export {toNormalizedAmount as formatToNormalizedAmount};

--- a/packages/web-lib/utils/format.number.test.ts
+++ b/packages/web-lib/utils/format.number.test.ts
@@ -13,47 +13,55 @@ describe('format.number', (): void => {
 		});
 
 		it('should format number correctly with default parameters', (): void => {
-			expect(amount(1234.56)).toBe('1 234,56');
+			expect(amount({amount: 1234.56})).toBe('1 234,56');
+			expect(amount({amount: 0.0000012345678})).toBe('0,000001');
+			expect(amount({amount: 0.0000000000015678})).toBe('0,000000000002');
+			expect(amount({amount: 0.000000000000000015678})).toBe('0,00000000000000001568');
+			expect(amount({amount: 0.000000000000000000000015678})).toBe('0,00'); // Too small to be displayed
 		});
 
 		it('should format string number correctly with default parameters', (): void => {
-			expect(amount('1234.56')).toBe('1 234,56');
+			expect(amount({amount: '1234.56'})).toBe('1 234,56');
+			expect(amount({amount: '0.0000012345678'})).toBe('0,000001');
+			expect(amount({amount: '0.0000000000015678'})).toBe('0,000000000002');
+			expect(amount({amount: '0.000000000000000015678'})).toBe('0,00000000000000001568');
+			expect(amount({amount: '0.000000000000000000000015678'})).toBe('0,00'); // Too small to be displayed
 		});
 
 		it('should format number with custom minimum and maximum fraction digits', (): void => {
-			expect(amount(1234.5678, 3, 4)).toBe('1 234,5678');
+			expect(amount({amount: 1234.5678, fractionDigits: {min: 3, max: 4}})).toBe('1 234,5678');
 		});
 
 		it('should handle maximumFractionDigits less than minimumFractionDigits', (): void => {
-			expect(amount(1234.56, 3, 1)).toBe('1 234,560');
+			expect(amount({amount: 1234.56, fractionDigits: {min: 3, max: 1}})).toBe('1 234,560');
 		});
 
 		it('should format number with ellipsis in the middle', (): void => {
-			expect(amount(12345678912345678, 0, 0, 12)).toBe('12 345...45 678');
+			expect(amount({amount: 12345678912345678, fractionDigits: {min: 0, max: 0}, displayDigits: 12})).toBe('12 345...45 678');
 		});
 
 		it('should format number with decimal part and ellipsis in the middle', (): void => {
-			expect(amount(123451234567.6789, 2, 2, 10)).toBe('123 4...67,68');
+			expect(amount({amount: 123451234567.6789, fractionDigits: {min: 2, max: 2}, displayDigits: 10})).toBe('123 4...67,68');
 		});
 
 		it('should not apply ellipsis if displayDigits is larger than the formatted amount length', (): void => {
-			expect(amount(121234567834.56, 2, 2, 20)).toBe(
+			expect(amount({amount: 121234567834.56, fractionDigits: {min: 2, max: 2}, displayDigits: 20})).toBe(
 				'121 234 567 834,56'
 			);
 		});
 
 		it('should not apply ellipsis if displayDigits is not provided', (): void => {
-			expect(amount(1234123456756789, 0, 0)).toBe(
+			expect(amount({amount: 1234123456756789, fractionDigits: {min: 0, max: 0}})).toBe(
 				'1 234 123 456 756 789'
 			);
 		});
 
 		it('should handle non-numeric input as 0', (): void => {
-			expect(amount('not-a-number')).toBe('0,00');
+			expect(amount({amount: 'not-a-number'})).toBe('0,00');
 		});
 
 		it('should handle NaN input as 0', (): void => {
-			expect(amount(NaN)).toBe('0,00');
+			expect(amount({amount: NaN})).toBe('0,00');
 		});
 	});
 

--- a/packages/web-lib/utils/format.number.ts
+++ b/packages/web-lib/utils/format.number.ts
@@ -2,13 +2,22 @@
 ** Bunch of function using the power of the browsers and standard functions
 ** to correctly format numbers, currency and date
 **************************************************************************/
-export function	amount(amount: number | string, minimumFractionDigits = 2, maximumFractionDigits = 2, displayDigits = 0): string {
-	let		locale = 'fr-FR';
+type TAmount = {
+	amount: number | string;
+	fractionDigits?: {
+		min: number;
+		max: number;
+	},
+	displayDigits?: number;
+};
+
+export function	amount({amount, fractionDigits = {min: 2, max: 2}, displayDigits = 0}: TAmount): string {
+	let locale = 'fr-FR';
 	if (typeof(navigator) !== 'undefined') {
 		locale = navigator.language || 'fr-FR';
 	}
-	if (maximumFractionDigits < minimumFractionDigits) {
-		maximumFractionDigits = minimumFractionDigits;
+	if (fractionDigits.max < fractionDigits.min) {
+		fractionDigits.max = fractionDigits.min;
 	}
 	if (!amount) {
 		amount = 0;
@@ -19,7 +28,26 @@ export function	amount(amount: number | string, minimumFractionDigits = 2, maxim
 	if (isNaN(amount)) {
 		amount = 0;
 	}
-	let formattedAmount = new Intl.NumberFormat([locale, 'en-US'], {minimumFractionDigits, maximumFractionDigits}).format(amount);
+
+	if (amount < 0.01) {
+		fractionDigits.max = getSmallAmountFractionDigits(amount);
+	}
+
+	if (fractionDigits.max < fractionDigits.min) {
+		fractionDigits.max = fractionDigits.min;
+	}
+
+	if (fractionDigits.max < fractionDigits.min) {
+		fractionDigits.max = fractionDigits.min;
+	}
+
+	let formattedAmount = new Intl.NumberFormat(
+		[locale, 'en-US'],
+		{
+			minimumFractionDigits: fractionDigits.min,
+			maximumFractionDigits: fractionDigits.max
+		}
+	).format(amount);
 	
 	if (displayDigits > 0 && formattedAmount.length > displayDigits) {
 		const leftSide = formattedAmount.slice(0, Math.ceil(displayDigits / 2));
@@ -61,22 +89,38 @@ export function withUnit(amount: number, minimumFractionDigits = 2, maximumFract
 	}).format(amount));
 }
 
-export const formatUSD = (n: number, min = 2, max = 2): string => `$ ${amount(n || 0, min, max)}`;
+export const formatUSD = (n: number, min = 2, max = 2): string => `$ ${amount({amount: n || 0, fractionDigits: {min, max}})}`;
 
 export const formatPercent = (n: number, min = 2, max = 2, upperLimit = 500): string => {
 	const	safeN = n || 0;
 	if (safeN > upperLimit) {
-		return `≧ ${amount(upperLimit, min, max)}%`;
+		return `≧ ${amount({amount: upperLimit, fractionDigits: {min, max}})}%`;
 	}
-	return `${amount(safeN || 0, min, max)}%`;
+	return `${amount({amount: safeN || 0, fractionDigits: {min, max}})}%`;
 };
 
 export const formatNumberOver10K = (n: number): string => {
 	if (n >= 10000) {
-		return amount(n, 0, 0) ?? '';
+		return amount({amount: n, fractionDigits: {min: 0, max: 0}}) ?? '';
 	}
-	return amount(n) ?? '';
+	return amount({amount: n}) ?? '';
 };
+
+function getSmallAmountFractionDigits(amount: number): number {
+	if (amount > 0.000001) {
+		return 6;
+	}
+	if (amount > 0.00000001) {
+		return 8;
+	}
+	if (amount > 0.000000000001) {
+		return 12;
+	}
+	if (amount > 0.0000000000000001) {
+		return 16;
+	}
+	return 20;
+}
 
 export {amount as formatAmount};
 export {currency as formatCurrency};

--- a/packages/web-lib/utils/format.number.ts
+++ b/packages/web-lib/utils/format.number.ts
@@ -6,7 +6,7 @@ type TAmount = {
 	amount: number | string;
 	fractionDigits?: {
 		min: number;
-		max: number;
+		max?: number;
 	},
 	displayDigits?: number;
 };
@@ -16,7 +16,7 @@ export function	amount({amount, fractionDigits = {min: 2, max: 2}, displayDigits
 	if (typeof(navigator) !== 'undefined') {
 		locale = navigator.language || 'fr-FR';
 	}
-	if (fractionDigits.max < fractionDigits.min) {
+	if ((fractionDigits.max ?? 2) < fractionDigits.min) {
 		fractionDigits.max = fractionDigits.min;
 	}
 	if (!amount) {
@@ -33,11 +33,11 @@ export function	amount({amount, fractionDigits = {min: 2, max: 2}, displayDigits
 		fractionDigits.max = getSmallAmountFractionDigits(amount);
 	}
 
-	if (fractionDigits.max < fractionDigits.min) {
+	if (fractionDigits.max ?? 2 < fractionDigits.min) {
 		fractionDigits.max = fractionDigits.min;
 	}
 
-	if (fractionDigits.max < fractionDigits.min) {
+	if (fractionDigits.max ?? 2 < fractionDigits.min) {
 		fractionDigits.max = fractionDigits.min;
 	}
 

--- a/packages/web-lib/utils/format.value.ts
+++ b/packages/web-lib/utils/format.value.ts
@@ -2,14 +2,14 @@ import {formatAmount} from '@yearn-finance/web-lib/utils/format.number';
 
 export function	counterValue(amount: number | string, price: number): string {
 	if (!amount || !price) {
-		return (`$${formatAmount(0, 2, 2)}`);
+		return (`$${formatAmount({amount: 0, fractionDigits: {min: 2, max: 2}})}`);
 	}
 
 	const value = (Number(amount) || 0) * (price || 0);
 	if (value > 10000) {
-		return (`$${formatAmount(value, 0, 0)}`);
+		return (`$${formatAmount({amount: value, fractionDigits: {min: 0, max: 0}})}`);
 	}
-	return (`$${formatAmount(value, 2, 2)}`);
+	return (`$${formatAmount({amount: value, fractionDigits: {min: 2, max: 2}})}`);
 }
 
 export function	counterValueRaw(amount: number | string, price: number): string {
@@ -18,9 +18,9 @@ export function	counterValueRaw(amount: number | string, price: number): string 
 	}
 	const value = (Number(amount) || 0) * (price || 0);
 	if (value > 10000) {
-		return (formatAmount(value, 0, 0));
+		return (formatAmount({amount: value, fractionDigits: {min: 0, max: 0}}));
 	}
-	return (formatAmount(value, 2, 2));
+	return (formatAmount({amount: value, fractionDigits: {min: 2, max: 2}}));
 }
 
 export {counterValue as formatCounterValue};


### PR DESCRIPTION
## Description

<!--- Describe your changes -->

* Add support to small numbers 
* Refactor the function to use named params

## Related Issue

<!--- Please link to the issue here -->

Related to https://github.com/yearn/yearn.fi/issues/267

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

Display more useful information 

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

`packages/web-lib/utils/format.number.test.ts`

Linked this branch to yearn.fi and tested in dev

