### PR TITLE
feat: Add Avalanche to web-lib supported chains

### DIFF
--- a/packages/web-lib/utils/web3/chains.ts
+++ b/packages/web-lib/utils/web3/chains.ts
@@ -210,6 +210,13 @@ const CHAINS: TNDict<TChain> = {
 				'decimals': 18
 			}
 		}
+	},
+	43114: {
+		'chainID': '43114',
+		'name': 'Avalanche Mainnet',
+		'displayName': 'Avalanche',
+		'coin': 'AVAX',
+		'block_explorer': 'https://snowtrace.io'
 	}
 };
 export {CHAINS as chains};


### PR DESCRIPTION
## Description

Since ape tax uses web-lib for network details we need to add Avalanche network details to web-lib so that ape tax has the options to show Avalanche as a supported network.

## Motivation and Context

Required for ape tax V3 integration 

## How Has This Been Tested?

Linked local version of web-lib with this change to ape tax and Avalanche network is now displayed as an option

## Screenshots (if appropriate):

<img width="1416" alt="AVAX" src="https://github.com/yearn/web-lib/assets/95051992/034a5b99-afa4-4106-973d-608f4f2bf3d5">

