### PR TITLE
fix: small numbers format

### DIFF
--- a/src/utils/format.number.ts
+++ b/src/utils/format.number.ts
@@ -161,13 +161,13 @@ export function formatLocalAmount(
 	** "decimals" number of decimals
 	**********************************************************************************************/
 	if (amount < 0.01) {
-		if (amount > 0.00000001) {
-			return formatCurrencyWithPrecision({amount, maxFractionDigits: 8, intlOptions, locale, symbol});
-		}
-		if (amount > 0.000000000001) {
+		if (amount <= 0.000000000001) {
 			return formatCurrencyWithPrecision({amount, maxFractionDigits: 12, intlOptions, locale, symbol});
+		} else if (amount <= 0.00000001) {
+			return formatCurrencyWithPrecision({amount, maxFractionDigits: 8, intlOptions, locale, symbol});
+		} else {
+			return formatCurrencyWithPrecision({amount, maxFractionDigits: decimals, intlOptions, locale, symbol});
 		}
-		return formatCurrencyWithPrecision({amount, maxFractionDigits: decimals, intlOptions, locale, symbol});
 	}
 	return (
 		new Intl.NumberFormat([locale, 'en-US'], intlOptions)


### PR DESCRIPTION
## Description

The amount was evaluated wrong when the numbers where very small. I changed the IF taking care of that to work correctly.

## Motivation and Context

Very small numbers were not shown correctly

## How Has This Been Tested?
With the tests in the lib

## Screenshots (if appropriate):
![IMAGE 2023-10-04 12:22:39](https://github.com/yearn/web-lib/assets/839844/afb0221c-7912-4a8a-9c6f-742e546dbf11)

